### PR TITLE
Show btc address on mobile devices

### DIFF
--- a/public/javascripts/wafflestats.js
+++ b/public/javascripts/wafflestats.js
@@ -228,7 +228,7 @@ $(document).ready(function() {
 					false);
 		}
 		
-		$('#btcAddress').val(address);
+		$('.btcAddress').val(address);
 		$('#notifications').attr("href", "/notifications/"+address);
 	}
 	

--- a/views/waffleStats.jade
+++ b/views/waffleStats.jade
@@ -29,7 +29,7 @@ mixin timeScale(name)
 block header
   form.navbar-form.navbar-left.hidden-xs.hidden-sm(role="address", name="stats", action="/stats", method="get")
       .form-group
-        input.form-control(type="text", placeholder="Bitcoin Address", size="45", name="address", id="btcAddress")
+        input.form-control(type="text", placeholder="Bitcoin Address", size="45", name="address", class="btcAddress")
       button.btn.btn-success(type="submit")
         i.fa.fa-refresh.fa-lg
   .nav.navbar-nav.navbar-right
@@ -52,6 +52,13 @@ block content
       
   .container-fluid
     .row
+      .col-md-2.hidden-lg.hidden-md
+        form(role="address", name="stats", action="/stats", method="get")
+          .input-group
+            input.form-control(type="text", placeholder="Bitcoin Address", size="45", name="address", class="btcAddress")
+            span.input-group-btn
+              button.btn.btn-success(type="submit")
+                i.fa.fa-refresh.fa-lg
       .col-md-2.text-center.nowrap
         h3 Current Balances
         br


### PR DESCRIPTION
Hi Mister Will,

I noticed that when I browsed using a mobile device, I could not check or input another BTC address.

This pull request fix this, adding a new BTC address outside the navigation menu, above the current balances and the historical balances graphs.
